### PR TITLE
Fixed multi-cam initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can trigger a homekit rich notification from outside with a simple curl comm
 
 ## Installation
 
-1. Install ffmpeg on your Mac
+1. Install ffmpeg on your computer
 2. Install this plugin using: npm install -g homebridge-videodoorbell
 3. Edit ``config.json`` and add the camera.
 3. Run Homebridge

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A small webserver is opened to interface with the physical world. By opening the
 ## Triggering HomeKit rich notifications
 
 You can trigger a homekit rich notification from outside with a simple curl command:
-curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:PORT_DEFINED_IN_CONFIG
+`curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:PORT_DEFINED_IN_CONFIG`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ You can trigger a homekit rich notification from outside with a simple curl comm
 
 #### Optional Parameters
 
-## global per-camera parameters
+##### global per-camera parameters
 * `port` is the HTTP port that the doorbell listens on, default 5005
 * `throttle` is the amount of time in milliseconds that the plugin waits before sending a new doorbell message to HomeKit, for clients that spawn a lot of messages, default 10000
-## videoConfig Parameters
+##### videoConfig Parameters
 * `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
 * `maxWidth` is the maximum width of the generated stream to avoid unnecessary upscaling, default 1280
 * `maxHeight` is the maximum height of the generated stream to avoid unnecessary upscaling, default 720

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ You can trigger a homekit rich notification from outside with a simple curl comm
 
     {
       "platform": "Video-doorbell",
-      "port": 5005,
       "cameras": [
         {
           "name": "Camera Name",
+          "port": 5005,
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
             "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/homebridge-videodoorbell.svg)](https://badge.fury.io/js/homebridge-videodoorbell)
 
-Video-Doorbell plugin based on [homebridge-camera-ffmpeg](https://github.com/KhaosT/homebridge-camera-ffmpeg) 
+Video-Doorbell plugin based on [homebridge-camera-ffmpeg](https://github.com/KhaosT/homebridge-camera-ffmpeg)
 for [Homebridge](https://github.com/nfarina/homebridge)
 
 Bring your doorbell to trigger a web request and you will receive a "doorbell" notification with snapshot at your mobile phone!   
@@ -11,8 +11,8 @@ Compared to a "simple" camera plugin this plugin uses the homekit video doorbell
 A small webserver is opened to interface with the physical world. By opening the site (or triggering with a script) a "doorbell" notification with snapshot is send to all icloud connected devices. If the same (homekit) room containing this camera also has a Lock mechanism accessory, the notification will show a working UNLOCK button. Homekit/iOS will link them together automatically when they are in the same room.
 
 ## Triggering HomeKit rich notifications
- 
-You can trigger a homekit rich notification from outside with a simple curl command: 
+
+You can trigger a homekit rich notification from outside with a simple curl command:
 curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:PORT_DEFINED_IN_CONFIG
 
 ## Installation
@@ -27,17 +27,13 @@ curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:POR
 
     {
       "platform": "Video-doorbell",
+      "port": 5005,
       "cameras": [
         {
           "name": "Camera Name",
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
             "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-          	"maxStreams": 2,
-          	"maxWidth": 1280,
-          	"maxHeight": 720,
-          	"maxFPS": 30,
-          	"port": 5005    
           }
         }
       ]
@@ -45,9 +41,13 @@ curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:POR
 
 #### Optional Parameters
 
-* `vcodec`, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
-* `audio`, can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see http://praveen.life/2016/06/26/compile-ffmpeg-for-raspberry-pi-3/
-* `packetSize`, can be set to a multiple of 188, default 1316. If audio or video is choppy try a smaller value.
+* `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
+* `maxWidth` is the maximum width of the generated stream to avoid unnecessary upscaling, default 1280
+* `maxHeight` is the maximum height of the generated stream to avoid unnecessary upscaling, default 720
+* `maxFPS` is the maximum frame rate of the stream, default 10
+* `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
+* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
+* `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 
 ```
 {
@@ -55,6 +55,7 @@ curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:POR
   "cameras": [
     {
       "name": "Camera Name",
+      "port": 5005,
       "videoConfig": {
       	"source": "-re -i rtsp://myfancy_rtsp_stream",
         "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
@@ -64,53 +65,9 @@ curl -X POST -d 'ding=dong&dong=ding' http://IP_OF_HOMEBRIDGE_RUNNING_DEVICE:POR
       	"maxFPS": 30,
       	"vcodec": "h264_omx",
       	"audio": true,
-      	"packetSize": 188,
-        "port": 5005  
+      	"packetSize": 188
       }
     }
   ]
 }
 ```
-
-## Uploading to Google Drive of Still Images ( Snapshots )
-
-This is an optional feature that will automatically store every snapshot taken to your Google Drive account as a photo.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.
-
-The snaphots are stored in a folder called "Camera Pictures", and are named with camera name, date and time of the image.
-
-To enable this feature, please add a new config option "uploader", and follow the steps below.
-
-* Add the option "uploader" to your config.json i.e.
-
-```
-{
-  "platform": "Video-doorbell",
-  "cameras": [
-    {
-      "name": "Camera Name",
-      "uploader": true,
-      "videoConfig": {
-      	"source": "-re -i rtsp://myfancy_rtsp_stream",
-        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-      	"maxStreams": 2,
-      	"maxWidth": 1280,
-      	"maxHeight": 720,
-      	"maxFPS": 30,
-      	"vcodec": "h264_omx",
-	    "port": 5005         
-      }
-    }
-  ]
-}
-```
-
-If the option is missing, it defaults to false, and does not enable the uploader.
-
-* For the setup of Google Drive, please follow the Google Drive Quickstart for Node.js instructions from here except for these changes.
-
-https://developers.google.com/drive/v3/web/quickstart/nodejs
-
-* In Step 1-h the working directory should be the .homebridge directory
-* Skip Step 2 and 3
-* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follow steps a to c
-

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ You can trigger a homekit rich notification from outside with a simple curl comm
 
 #### Optional Parameters
 
+## global per-camera parameters
+* `port` is the HTTP port that the doorbell listens on, default 5005
+* `throttle` is the amount of time in milliseconds that the plugin waits before sending a new doorbell message to HomeKit, for clients that spawn a lot of messages, default 10000
+## videoConfig Parameters
 * `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
 * `maxWidth` is the maximum width of the generated stream to avoid unnecessary upscaling, default 1280
 * `maxHeight` is the maximum height of the generated stream to avoid unnecessary upscaling, default 720
@@ -56,6 +60,7 @@ You can trigger a homekit rich notification from outside with a simple curl comm
     {
       "name": "Camera Name",
       "port": 5005,
+      "throttle": 3000,
       "videoConfig": {
       	"source": "-re -i rtsp://myfancy_rtsp_stream",
       	"stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can trigger a homekit rich notification from outside with a simple curl comm
           "port": 5005,
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
-            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+          	"stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
           }
         }
       ]
@@ -58,7 +58,7 @@ You can trigger a homekit rich notification from outside with a simple curl comm
       "port": 5005,
       "videoConfig": {
       	"source": "-re -i rtsp://myfancy_rtsp_stream",
-        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+      	"stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
       	"maxStreams": 2,
       	"maxWidth": 1280,
       	"maxHeight": 720,

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -45,9 +45,9 @@ function FFMPEG(hap, cameraConfig) {
   var numberOfStreams = ffmpegOpt.maxStreams || 2;
   var videoResolutions = [];
 
-  this.maxWidth = ffmpegOpt.maxWidth;
-  this.maxHeight = ffmpegOpt.maxHeight;
-  var maxFPS = (ffmpegOpt.maxFPS > 30) ? 30 : ffmpegOpt.maxFPS;
+  this.maxWidth = ffmpegOpt.maxWidth || 1280;
+  this.maxHeight = ffmpegOpt.maxHeight || 720;
+  var maxFPS = (ffmpegOpt.maxFPS > 30) ? 30 : ffmpegOpt.maxFPS || 10;
 
   if (this.maxWidth >= 320) {
     if (this.maxHeight >= 240) {
@@ -334,12 +334,11 @@ FFMPEG.prototype.createCameraControlService = function() {
   var controlService = new Service.CameraControl();
 
   this.services.push(controlService);
-  
+
   if(this.audio){
     var microphoneService = new Service.Microphone();
     this.services.push(microphoneService);
   }
-  
 }
 
 // Private

--- a/index.js
+++ b/index.js
@@ -108,34 +108,34 @@ videodoorbellPlatform.prototype.didFinishLaunching = function () {
             //}.bind(this), 10000);
 
 
-            self.api.publishCameraAccessories("Video-doorbell", configuredAccessories);
 
-            var createBellEvent = throttle(function() {
-                // All the taxing stuff you do
+            videodoorbellAccessory.createBellEvent = throttle(function() {
                 self.EventWithAccessory(videodoorbellAccessory);
                 self.log("Video-doorbell %s rang!", cameraName);
             }, 10000);
 
             // Create http-server to trigger doorbell from outside:
             // curl -X POST -d 'ding=dong&dong=ding' http://HOMEBRIDGEIP:PORT
-            var server = http.createServer(function (req, res) {
+            videodoorbellAccessory.server = http.createServer(function (req, res) {
                 req.pipe(concat(function (body) {
                   var params = qs.parse(body.toString());
                   res.end(JSON.stringify(params) + '\n');
                   // todo: add validation
-                  createBellEvent();
+                  videodoorbellAccessory.createBellEvent();
                 }));
             });
 
             //var server = http.createServer(self.handleRequest.bind(this));
-            server.listen(webserverPort, function () {
+            videodoorbellAccessory.server.listen(webserverPort, function () {
                 console.log("Video-doorbell %s is listening on port %s", cameraName, webserverPort);
             }.bind(this));
 
-	    server.on('error', function (err) {
+            videodoorbellAccessory.server.on('error', function (err) {
                 console.log("Video-doorbell %s Port %s Server %s ", cameraName, webserverPort, err);
             }.bind(this));
         });
+
+        self.api.publishCameraAccessories("Video-doorbell", configuredAccessories);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ videodoorbellPlatform.prototype.didFinishLaunching = function () {
             var cameraName = cameraConfig.name;
             var videoConfig = cameraConfig.videoConfig;
             var webserverPort = cameraConfig.port || 5005;
+            var throttleAmount = cameraConfig.throttle || 10000;
 
             if (!cameraName || !videoConfig) {
                 console.log("Missing parameters.");
@@ -107,12 +108,10 @@ videodoorbellPlatform.prototype.didFinishLaunching = function () {
             //primaryService.getCharacteristic(Characteristic.ProgrammableSwitchEvent).setValue(0);
             //}.bind(this), 10000);
 
-
-
             videodoorbellAccessory.createBellEvent = throttle(function() {
                 self.EventWithAccessory(videodoorbellAccessory);
                 self.log("Video-doorbell %s rang!", cameraName);
-            }, 10000);
+            }, throttleAmount);
 
             // Create http-server to trigger doorbell from outside:
             // curl -X POST -d 'ding=dong&dong=ding' http://HOMEBRIDGEIP:PORT

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ videodoorbellPlatform.prototype.didFinishLaunching = function () {
         cameras.forEach(function (cameraConfig) {
             var cameraName = cameraConfig.name;
             var videoConfig = cameraConfig.videoConfig;
-            var webserverPort = videoConfig.port || 5005;
+            var webserverPort = cameraConfig.port || 5005;
 
             if (!cameraName || !videoConfig) {
                 console.log("Missing parameters.");


### PR DESCRIPTION
This PR fixes multiple camera initialization, the http server was generated multiple times as the whole configuration was pushed multiple times.

It also adds a throttle of 10s to the event firing so that the message is only sent once every 10 seconds (by default).

Plus the parameters all have default values now.

The "port" parameter is back in the global settings as I think it makes more sense there.