### PR TITLE
videoFilter, hflip and vflip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ You can also show a trigger button in HomeKit that activates the doorbell notifi
 * `maxBitrate` is the maximum frame rate of the stream in kbit/s, default 300
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see above, default false
+* `vflip` Flips the stream vertically, default `false`. Ignored if you use `vcodec` with `copy` value.
+* `hflip` Flips the stream horizontally, default `false`. Ignored if you use `vcodec` with `copy` value.
+* `videoFilter` Allows a custom video filter to be passed to FFmpeg via `-vf`, defaults to `scale=1280:720`. Ignored if you use `vcodec` with `copy` value.
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 * `debug` Show the output of ffmpeg in the log, default false
 


### PR DESCRIPTION
This PR adds the `videoFilter`, `hflip` and `vflip` keys (same code as homebridge-camera-ffmpeg)
Those keys are ignored if `vcodec` is set as `copy`.

Close #41 